### PR TITLE
Added legacy permission to arguments

### DIFF
--- a/Rfacebook/R/fbOAuth.R
+++ b/Rfacebook/R/fbOAuth.R
@@ -87,7 +87,7 @@
 #'
 
 
-fbOAuth <- function(app_id, app_secret, extended_permissions=FALSE)
+fbOAuth <- function(app_id, app_secret, extended_permissions=FALSE, legacy_permissions=FALSE)
 {
 	## getting callback URL
 	full_url <- oauth_callback()
@@ -103,9 +103,13 @@ fbOAuth <- function(app_id, app_secret, extended_permissions=FALSE)
 	myapp <- oauth_app("facebook", app_id, app_secret)
 	if (extended_permissions==TRUE){
 		scope <- paste("user_birthday,user_hometown,user_location,user_relationships,",
-			"publish_actions,user_status,user_likes,read_stream", collapse="")
+			"publish_actions,user_status,user_likes", collapse="")
 	}
 	else { scope <- "public_profile,user_friends"}
+	
+	if (legacy_permissions==TRUE) {
+	  scope <- paste(scope, "read_stream", sep = ",")
+	}
 
 	## with early httr versions
 	if (packageVersion('httr') <= "0.2"){


### PR DESCRIPTION
Facebook's documentation for scope permissions states the following for read_stream:

`This permission is only available for apps using Graph API version v2.3 or older.`

If you try to run fbOAuth with extended_permissions, you got this error:

`Invalid Scopes: read_stream. This message is only shown to developers. Users of your app will ignore these permissions if present. Please read the documentation for valid permissions at: https://developers.facebook.com/docs/facebook-login/permissions`

This patch fixes it by creating a legacy_permissions, but I think that the scope permissions should be an array, defaulted to the non-extended permissions. It seems more flexible this way.
