### PR TITLE
Insights multimetrics

### DIFF
--- a/Rfacebook/R/getInsights.R
+++ b/Rfacebook/R/getInsights.R
@@ -7,6 +7,9 @@
 #' @description
 #' \code{getInsights} retrieves information from an owned Facebook page. Note 
 #' that you must specify wich metric from insights you need and the period.
+#' To request multiple metrics at one time, pass a vector of metric names with a vector
+#' of periods of the same length. If only one period is supplied, it will apply to each metric.
+#' Please refer to Facebook's documentation for valid combinations of objects, metrics and periods.
 #'
 #' @details
 #' The current list of supported metrics and periods is: page_fan_adds, page_fan_removes, 
@@ -14,7 +17,7 @@
 #' page_impressions, page_posts_impressions, page_consumptions, post_consumptions_by_type, 
 #' page_consumptions, and page_fans_country.
 #'
-#' For more information, see: \url{https://developers.facebook.com/docs/graph-api/reference/v2.1/insights}
+#' For more information, see: \url{https://developers.facebook.com/docs/graph-api/reference/v2.5/insights}
 #'
 #' @author
 #' Danilo Silva \email{silvadaniloc@@gmail.com}
@@ -27,7 +30,7 @@
 #' \url{https://developers.facebook.com/tools/explorer} or the OAuth token 
 #' created with \code{fbOAuth}.
 #'
-#' @param metric The metric which you want to get values for.
+#' @param metric The metric(s) which you want to get values for.
 #'
 #' @param period Time intervals to return
 #' 
@@ -53,8 +56,13 @@
 #' ## Getting page fans for date range
 #' ## (only owner or admin of page)
 #' insights <- getInsights(object_id='221568044327801',
-#'     token=fb_oauth, metric='page_fans', period='lifetime', 
-#'     parms='&since=2015-01-01&until=2015-01-31')     
+#'     token=fb_oauth, metric=c'page_fans', period='lifetime', 
+#'     parms='&since=2015-01-01&until=2015-01-31')
+#' #' ## Getting page fans AND page impressions for date range
+#' ## (only owner or admin of page)
+#' insights <- getInsights(object_id='221568044327801',
+#'     token=fb_oauth, metric=c('page_fans','page_impressions'), period=c('lifetime','day'), 
+#'     parms='&since=2015-01-01&until=2015-01-31')        
 #' ## Count of fans by country
 #'   insights <- getInsights(object_id='221568044327801_754789777921289', 
 #'      token=fb_oauth, metric='page_fans_country', period='lifetime')

--- a/Rfacebook/R/getInsights.R
+++ b/Rfacebook/R/getInsights.R
@@ -63,32 +63,31 @@
 
 getInsights <- function(object_id, token, metric, period='day', parms=NA, n=5){ 
   
-## HANDLE PERIOD AND METRIC LENGTH MISMATCHING
-if (length(metric)!=length(period) & length(period)!=1) {
-          stop("Number of periods must either match the number of metrics or be one.")
-}
+  ## HANDLE PERIOD AND METRIC LENGTH MISMATCHING
+  if (length(metric)!=length(period) & length(period)!=1) {
+        stop("Number of periods must either match the number of metrics or be one.")
+  }
+  
+  if(length(metric)!=length(period) & length(period)==1) { 
+        period <- rep(period,length(metric))
+  } else {
+        period <- period
+  }
 
-if(length(metric)!=length(period) & length(period)==1) { 
-          period <- rep(period,length(metric))
-} else {
-          period <- period
-}
 
-
-### CREATE LIST OF REQUEST URLS
-url <- list()
-for (i in 1:length(metric)) {
-
-          url[i] <- paste0(
-                              'https://graph.facebook.com/', 
-                              object_id, 
-                              '/insights/', 
-                              metric[i], 
-                              '?period=',
-                              period[i], 
-                              ifelse(is.na(parms),'', parms) 
-)
-}
+  ### CREATE LIST OF REQUEST URLS
+  url <- list()
+  for (i in 1:length(metric)) {
+    url[i] <- paste0(
+      'https://graph.facebook.com/v2.5/', 
+      object_id, 
+      '/insights/', 
+      metric[i], 
+      '?period=',
+      period[i], 
+      ifelse(is.na(parms),'', parms) 
+  )
+  }
 
   ## LOOP THROUGH REQUEST URLS
   

--- a/Rfacebook/man/getInsights.Rd
+++ b/Rfacebook/man/getInsights.Rd
@@ -13,9 +13,9 @@ getInsights(object_id, token, metric, period = "day", parms = NA, n = 5)
 \url{https://developers.facebook.com/tools/explorer} or the OAuth token
 created with \code{fbOAuth}.}
 
-\item{metric}{The metric which you want to get values for.}
+\item{metric}{The metrics (or vector of metrics) which you want to get values for.}
 
-\item{period}{Time intervals to return}
+\item{period}{Time interval (or vector of time intervals) to return}
 
 \item{parms}{Optional argument that can be used to append additional
 parameters. For example, \code{&since=DATE&until=DATE}.}
@@ -26,7 +26,10 @@ n is 5}
 }
 \description{
 \code{getInsights} retrieves information from an owned Facebook page. Note
-that you must specify wich metric from insights you need and the period.
+that you must specify wich metric from insights you need and the period. 
+To request multiple metrics at one time, pass a vector of metric names with a vector
+of periods of the same length. If only one period is supplied, it will apply to each metric.
+Please refer to Facebook's documentation for valid combinations of objects, metrics, and periods.
 }
 \details{
 The current list of supported metrics and periods is: page_fan_adds, page_fan_removes,
@@ -34,7 +37,7 @@ page_views_login, page_views_login, page_views_logout, page_views, page_story_ad
 page_impressions, page_posts_impressions, page_consumptions, post_consumptions_by_type,
 page_consumptions, and page_fans_country.
 
-For more information, see: \url{https://developers.facebook.com/docs/graph-api/reference/v2.1/insights}
+For more information, see: \url{https://developers.facebook.com/docs/graph-api/reference/v2.5/insights}
 }
 \examples{
 \dontrun{
@@ -51,6 +54,11 @@ For more information, see: \url{https://developers.facebook.com/docs/graph-api/r
 ## (only owner or admin of page)
 insights <- getInsights(object_id='221568044327801',
     token=fb_oauth, metric='page_fans', period='lifetime',
+    parms='&since=2015-01-01&until=2015-01-31')
+## Getting page fans AND page impresions for date range
+## (only owner or admin of page)
+insights <- getInsights(object_id='221568044327801',
+    token=fb_oauth, metric=c('page_fans','page_impressions'), period=c('lifetime','day'), 
     parms='&since=2015-01-01&until=2015-01-31')
 ## Count of fans by country
   insights <- getInsights(object_id='221568044327801_754789777921289',


### PR DESCRIPTION
Addresses issue #52 

Provides the ability to pass a vector of metric names as well as a vector of periods of the same length to retrieve multiple metrics in one call. If only one period is supplied, it will apply to each metric.

It will be up to the user to understand the API enough to pass valid combinations of objects, metrics, and periods. If any combination in any request is wrong, the entire thing fails.

That error handling is not ideal in my opinion but I did not attempt to address that in this update since it would require changes to callAPI function defined in utils.R. That is a whole other discussion. For what it is worth, I think it would be great if errors did not kill the entire function but rather the error message was returned as a the result as well as printed to the console.