### PR TITLE
Fix nonexisting field in getCommentReplies method

### DIFF
--- a/Rfacebook/R/getCommentReplies.R
+++ b/Rfacebook/R/getCommentReplies.R
@@ -55,7 +55,7 @@ getCommentReplies <- function(comment_id, token, n=500, replies=TRUE, likes=FALS
                      n.replies=n){
   
   url <- paste0("https://graph.facebook.com/", comment_id,
-                "?fields=from,message,created_time,like_count,comment_count") #return initial comments
+                "?fields=from,message,created_time") #return initial comments
   
   if (replies==TRUE){
     url <- paste0(url, ",comments.summary(true).",

--- a/Rfacebook/R/utils.R
+++ b/Rfacebook/R/utils.R
@@ -242,8 +242,6 @@ replyDataToDF <- function(json){
     from_name = json$from$name,
     message = ifelse(!is.null(json$message),json$message, NA),
     created_time = json$created_time,
-    likes_count = json$like_count,
-	comments_count = json$comment_count,
     id = json$id,
 	stringsAsFactors=F)
   return(df)


### PR DESCRIPTION
When trying to retrieve comment replies, the method throws an error:
```
Error in callAPI(url = url, token = token) : 
  (#100) Tried accessing nonexisting field (like_count) on node type (Post)
```
Even when the documentation says those fields exists, they don't. I've tried to retrieve them with the Graph Api Explorer but it throws the same error.

Removing those fields from the url and the dataframe creation allows to get the replies to the comment.