### PR TITLE
Added reactions option to getPosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _test
 .Rapp.history
 credentials.dta
 creating-credentials.r
+.Rproj.user

--- a/Rfacebook/R/utils.R
+++ b/Rfacebook/R/utils.R
@@ -113,6 +113,22 @@ postDataToDF <- function(json){
 	return(df)
 }
 
+reactionsDataToDF <- function(json){
+  if (!is.null(json)){
+    df <- data.frame(
+      from_name = unlistWithNA(json, "name"),
+      from_type = unlistWithNA(json, "type"),
+      from_id = unlistWithNA(json, "id"),
+      stringsAsFactors=F
+    )
+  }
+  if (length(json)==0){
+    df <- NULL
+  }
+  return(df)
+}
+
+
 likesDataToDF <- function(json){
 	if (!is.null(json)){
 		df <- data.frame(


### PR DESCRIPTION
Hey @pablobarbera,

I added an option to getPosts to allow reactions other than likes (love, haha, wow, etc) to be fetched as well. It should be backwards compatible and I tried to stick to your coding style as close as possible, but let me know if there is anything you would like to see implemented differently

(I just noticed I also committed a .gitignore change, I can happily get rid of that if you want)

Cheers,

Wouter 