### PR TITLE
SearchPage function returns empty (Solved)

### DIFF
--- a/Rfacebook/R/searchPages.R
+++ b/Rfacebook/R/searchPages.R
@@ -35,7 +35,7 @@ searchPages <- function(string, token, n=200)
   if (length(string)>1){ string <- paste(string, collapse=" ") }
   
   url <- paste("https://graph.facebook.com/search?q=", string,
-               "&type=page&limit=", sep="")
+               "&type=place&limit=", sep="")
   if (n<=200){
     url <- paste(url, n, sep="")
   }


### PR DESCRIPTION
After the last update of the facebook graph api the command type = page is no longer accepted causing the query to return empty. To solve it, just change the type = page for type = place and it will work again.